### PR TITLE
Use latest patch version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.8
-  - 1.9
+  - 1.8.x
+  - 1.9.x
 
 branches:
   only:


### PR DESCRIPTION
`1.8.x` and `1.9.x` is latest patch version.

https://docs.travis-ci.com/user/languages/go/#Specifying-a-Go-version-to-use