### PR TITLE
res -> resp

### DIFF
--- a/client.go
+++ b/client.go
@@ -66,10 +66,10 @@ func (c *Client) newRequest(ctx context.Context, method, endpoint string, query 
 func (c *Client) get(ctx context.Context, endpoint string, params url.Values) (*http.Response, error) {
 	req, _ := c.newRequest(ctx, "GET", endpoint, params, nil)
 
-	res, err := c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 
-	return res, nil
+	return resp, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -118,20 +118,20 @@ func TestGet(t *testing.T) {
 		http.ServeFile(w, r, "testdata/users-7.json")
 	})
 
-	res, err := client.get(ctx, endpoint, query)
+	resp, err := client.get(ctx, endpoint, query)
 	if err != nil {
 		t.Fatalf("failed to GET request: %v", err)
 	}
 
 	expected := http.StatusOK
-	actual := res.StatusCode
+	actual := resp.StatusCode
 	if actual != expected {
 		t.Errorf("expected %v, got %v", expected, actual)
 	}
 
 	cancelCtx, cancel := context.WithCancel(ctx)
 	cancel()
-	res, err = client.get(cancelCtx, endpoint, nil)
+	resp, err = client.get(cancelCtx, endpoint, nil)
 	if err == nil {
 		t.Errorf("should return error, got %v", err)
 	}


### PR DESCRIPTION
Abbreviation of "Response" is `resp` by convention.

ex) https://golang.org/src/net/http/client.go